### PR TITLE
Make generators configurable in map JSON files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   modRuntime("supercoder79:databreaker:0.2.7") {
     exclude module: "fabric-loader"
   }
+  modImplementation include('fr.catcore:server-translations-api:1.4.0')
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   modRuntime("supercoder79:databreaker:0.2.7") {
     exclude module: "fabric-loader"
   }
-  modImplementation include('fr.catcore:server-translations-api:1.4.0')
+  modImplementation('fr.catcore:server-translations-api:1.4.0')
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.1
+yarn_mappings=1.17.1+build.61
 loader_version=0.11.6
 
 # Dependencies
-fabric_version=0.36.1+1.17
+fabric_version=0.40.1+1.17
 
 # Mod Properties
 mod_version=1.0.0

--- a/src/main/java/xyz/nucleoid/bedwars/BedWars.java
+++ b/src/main/java/xyz/nucleoid/bedwars/BedWars.java
@@ -3,7 +3,7 @@ package xyz.nucleoid.bedwars;
 import com.google.common.reflect.Reflection;
 import net.fabricmc.api.ModInitializer;
 import xyz.nucleoid.bedwars.custom.BwItems;
-import xyz.nucleoid.bedwars.game.BwConfig;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.BwWaiting;
 import xyz.nucleoid.bedwars.game.active.modifiers.BwGameModifiers;
 import xyz.nucleoid.bedwars.game.active.modifiers.BwGameTriggers;

--- a/src/main/java/xyz/nucleoid/bedwars/game/BwMap.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/BwMap.java
@@ -50,6 +50,10 @@ public final class BwMap {
 
     public ItemGeneratorPools pools;
 
+    public BwMap(BwConfig config) {
+        this.pools = new ItemGeneratorPools(config);
+    }
+
     public void setChunkGenerator(ChunkGenerator chunkGenerator) {
         this.chunkGenerator = chunkGenerator;
     }
@@ -215,11 +219,11 @@ public final class BwMap {
 
         private static ItemGeneratorPool poolForLevel(int level, ItemGeneratorPools pools) {
             if (level == 2) {
-                return pools.TEAM_LVL_2;
+                return pools.teamLvl2;
             } else if (level == 3) {
-                return pools.TEAM_LVL_3;
+                return pools.teamLvl3;
             }
-            return pools.TEAM_LVL_1;
+            return pools.teamLvl1;
         }
     }
 

--- a/src/main/java/xyz/nucleoid/bedwars/game/BwMapBuilder.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/BwMapBuilder.java
@@ -5,6 +5,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Heightmap;
 import xyz.nucleoid.bedwars.BedWars;
+import xyz.nucleoid.bedwars.game.active.ItemGeneratorPools;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.generator.BwSkyMapBuilder;
 import xyz.nucleoid.map_templates.BlockBounds;
 import xyz.nucleoid.map_templates.MapTemplate;
@@ -43,12 +45,13 @@ public final class BwMapBuilder {
         BwMap map = new BwMap();
 
         MapTemplateMetadata metadata = template.getMetadata();
+        map.pools = new ItemGeneratorPools(config);
         metadata.getRegionBounds("diamond_spawn").forEach(map::addDiamondGenerator);
         metadata.getRegionBounds("emerald_spawn").forEach(map::addEmeraldGenerator);
 
         for (GameTeam team : this.config.teams()) {
             BwMap.TeamRegions regions = BwMap.TeamRegions.fromTemplate(team.key(), metadata);
-            map.addTeamRegions(team.key(), regions);
+            map.addTeamRegions(team.key(), regions, new ItemGeneratorPools(config));
         }
 
         for (BlockPos pos : template.getBounds()) {

--- a/src/main/java/xyz/nucleoid/bedwars/game/BwMapBuilder.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/BwMapBuilder.java
@@ -5,7 +5,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Heightmap;
 import xyz.nucleoid.bedwars.BedWars;
-import xyz.nucleoid.bedwars.game.active.ItemGeneratorPools;
 import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.generator.BwSkyMapBuilder;
 import xyz.nucleoid.map_templates.BlockBounds;
@@ -42,16 +41,15 @@ public final class BwMapBuilder {
     }
 
     private BwMap buildFromTemplate(MinecraftServer server, MapTemplate template) {
-        BwMap map = new BwMap();
+        BwMap map = new BwMap(config);
 
         MapTemplateMetadata metadata = template.getMetadata();
-        map.pools = new ItemGeneratorPools(config);
         metadata.getRegionBounds("diamond_spawn").forEach(map::addDiamondGenerator);
         metadata.getRegionBounds("emerald_spawn").forEach(map::addEmeraldGenerator);
 
         for (GameTeam team : this.config.teams()) {
             BwMap.TeamRegions regions = BwMap.TeamRegions.fromTemplate(team.key(), metadata);
-            map.addTeamRegions(team.key(), regions, new ItemGeneratorPools(config));
+            map.addTeamRegions(team.key(), regions, map.pools);
         }
 
         for (BlockPos pos : template.getBounds()) {

--- a/src/main/java/xyz/nucleoid/bedwars/game/BwWaiting.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/BwWaiting.java
@@ -9,6 +9,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.GameMode;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.active.BwActive;
 import xyz.nucleoid.fantasy.RuntimeWorldConfig;
 import xyz.nucleoid.plasmid.game.GameOpenContext;

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
@@ -8,7 +8,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.FireworkRocketEntity;
-import net.minecraft.item.FireworkItem;
+import net.minecraft.item.FireworkRocketItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.scoreboard.AbstractTeam;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -21,7 +21,7 @@ import net.minecraft.world.GameMode;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.bedwars.BedWars;
 import xyz.nucleoid.bedwars.custom.MovingCloud;
-import xyz.nucleoid.bedwars.game.BwConfig;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.BwMap;
 import xyz.nucleoid.bedwars.game.BwSpawnLogic;
 import xyz.nucleoid.bedwars.game.active.modifiers.BwGameTriggers;
@@ -90,6 +90,8 @@ public final class BwActive {
     private GameTeam winningTeam;
     private long closeTime;
 
+    private final ItemGeneratorPools pools;
+
     final List<MovingCloud> movingClouds = new ArrayList<>();
 
     private BwActive(ServerWorld world, GameActivity activity, BwMap map, BwConfig config, TeamManager teams, GlobalWidgets widgets) {
@@ -112,6 +114,8 @@ public final class BwActive {
         this.spawnLogic = new BwSpawnLogic(this.world, map);
         this.bedDestruction = new BwBedDestruction(widgets);
         this.interactions = new BwInteractions(this);
+
+        this.pools = new ItemGeneratorPools(config);
     }
 
     public static void open(ServerWorld world, GameSpace gameSpace, BwMap map, BwConfig config, Multimap<GameTeamKey, ServerPlayerEntity> players) {
@@ -330,7 +334,7 @@ public final class BwActive {
             ServerPlayerEntity player = players.get(random.nextInt(players.size()));
 
             int flight = random.nextInt(3);
-            FireworkItem.Type type = random.nextInt(4) == 0 ? FireworkItem.Type.STAR : FireworkItem.Type.BURST;
+            FireworkRocketItem.Type type = random.nextInt(4) == 0 ? FireworkRocketItem.Type.STAR : FireworkRocketItem.Type.BURST;
             FireworkRocketEntity firework = new FireworkRocketEntity(
                     this.world,
                     player.getX(),
@@ -422,6 +426,10 @@ public final class BwActive {
 
     public int getTeamCount() {
         return this.teamStates.size();
+    }
+
+    public ItemGeneratorPools getPools() {
+        return pools;
     }
 
     @Nullable

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
@@ -90,8 +90,6 @@ public final class BwActive {
     private GameTeam winningTeam;
     private long closeTime;
 
-    private final ItemGeneratorPools pools;
-
     final List<MovingCloud> movingClouds = new ArrayList<>();
 
     private BwActive(ServerWorld world, GameActivity activity, BwMap map, BwConfig config, TeamManager teams, GlobalWidgets widgets) {
@@ -114,8 +112,6 @@ public final class BwActive {
         this.spawnLogic = new BwSpawnLogic(this.world, map);
         this.bedDestruction = new BwBedDestruction(widgets);
         this.interactions = new BwInteractions(this);
-
-        this.pools = new ItemGeneratorPools(config);
     }
 
     public static void open(ServerWorld world, GameSpace gameSpace, BwMap map, BwConfig config, Multimap<GameTeamKey, ServerPlayerEntity> players) {
@@ -426,10 +422,6 @@ public final class BwActive {
 
     public int getTeamCount() {
         return this.teamStates.size();
-    }
-
-    public ItemGeneratorPools getPools() {
-        return pools;
     }
 
     @Nullable

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/BwWinStateLogic.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/BwWinStateLogic.java
@@ -1,5 +1,6 @@
 package xyz.nucleoid.bedwars.game.active;
 
+import net.fabricmc.loader.api.FabricLoader;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.game.common.team.GameTeam;
 import xyz.nucleoid.plasmid.game.common.team.GameTeamKey;
@@ -21,6 +22,11 @@ public final class BwWinStateLogic {
 
         // if there's only one team, disable the win state
         if (this.game.getTeamCount() <= 1) {
+            return null;
+        }
+
+        // If this is a development environment, disable the win state
+        if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
             return null;
         }
 

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPool.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPool.java
@@ -1,14 +1,7 @@
 package xyz.nucleoid.bedwars.game.active;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.util.collection.WeightedList;
-import xyz.nucleoid.bedwars.game.config.BwConfig;
-import xyz.nucleoid.bedwars.game.config.GeneratorConfig;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
 
 public final class ItemGeneratorPool {
     private final WeightedList<ItemStack> pool = new WeightedList<>();

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPool.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPool.java
@@ -3,35 +3,14 @@ package xyz.nucleoid.bedwars.game.active;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.collection.WeightedList;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
+import xyz.nucleoid.bedwars.game.config.GeneratorConfig;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
 
 public final class ItemGeneratorPool {
-    public static final ItemGeneratorPool TEAM_LVL_1 = new ItemGeneratorPool()
-            .add(new ItemStack(Items.IRON_INGOT, 1), 10)
-            .add(new ItemStack(Items.GOLD_INGOT, 1), 2)
-            .spawnInterval(34);
-
-    public static final ItemGeneratorPool TEAM_LVL_2 = new ItemGeneratorPool()
-            .add(new ItemStack(Items.IRON_INGOT, 1), 10)
-            .add(new ItemStack(Items.IRON_INGOT, 2), 3)
-            .add(new ItemStack(Items.GOLD_INGOT, 1), 3)
-            .spawnInterval(30);
-
-    public static final ItemGeneratorPool TEAM_LVL_3 = new ItemGeneratorPool()
-            .add(new ItemStack(Items.IRON_INGOT, 1), 36)
-            .add(new ItemStack(Items.IRON_INGOT, 2), 18)
-            .add(new ItemStack(Items.GOLD_INGOT, 1), 9)
-            .add(new ItemStack(Items.GOLD_INGOT, 2), 3)
-            .add(new ItemStack(Items.EMERALD, 1), 1)
-            .spawnInterval(26);
-
-    public static final ItemGeneratorPool DIAMOND = new ItemGeneratorPool()
-            .add(new ItemStack(Items.DIAMOND, 1), 1)
-            .spawnInterval(20 * 45);
-
-    public static final ItemGeneratorPool EMERALD = new ItemGeneratorPool()
-            .add(new ItemStack(Items.EMERALD, 1), 1)
-            .spawnInterval(20 * 90);
-
     private final WeightedList<ItemStack> pool = new WeightedList<>();
     private long spawnInterval = 10;
 

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPools.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPools.java
@@ -1,17 +1,13 @@
 package xyz.nucleoid.bedwars.game.active;
 
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import xyz.nucleoid.bedwars.game.config.BwConfig;
-import xyz.nucleoid.bedwars.game.config.GeneratorConfig;
-
-import java.util.ArrayList;
 
 public class ItemGeneratorPools {
-    public final ItemGeneratorPool TEAM_LVL_1;
-    public final ItemGeneratorPool TEAM_LVL_2;
-    public final ItemGeneratorPool TEAM_LVL_3;
+    public final ItemGeneratorPool teamLvl1;
+    public final ItemGeneratorPool teamLvl2;
+    public final ItemGeneratorPool teamLvl3;
 
     public final ItemGeneratorPool DIAMOND;
 
@@ -20,18 +16,18 @@ public class ItemGeneratorPools {
     public ItemGeneratorPools(BwConfig config) {
         var generatorConfig = config.generatorConfig();
 
-        TEAM_LVL_1 = new ItemGeneratorPool()
+        teamLvl1 = new ItemGeneratorPool()
                 .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level1().ironSpawnRate())
                 .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level1().goldSpawnRate())
                 .spawnInterval(generatorConfig.level1().spawnIntervalTicks());
 
-        TEAM_LVL_2 = new ItemGeneratorPool()
+        teamLvl2 = new ItemGeneratorPool()
                 .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level2().ironSpawnRate())
                 .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level2().goldSpawnRate())
                 .add(new ItemStack(Items.IRON_INGOT, 2), generatorConfig.level2().ironSpawnRate() / 3)
                 .spawnInterval(generatorConfig.level2().spawnIntervalTicks());
 
-        TEAM_LVL_3 = new ItemGeneratorPool()
+        teamLvl3 = new ItemGeneratorPool()
                 .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level3().ironSpawnRate())
                 .add(new ItemStack(Items.IRON_INGOT, 2), generatorConfig.level3().ironSpawnRate() / 2)
                 .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level3().goldSpawnRate())

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPools.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/ItemGeneratorPools.java
@@ -1,0 +1,50 @@
+package xyz.nucleoid.bedwars.game.active;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
+import xyz.nucleoid.bedwars.game.config.GeneratorConfig;
+
+import java.util.ArrayList;
+
+public class ItemGeneratorPools {
+    public final ItemGeneratorPool TEAM_LVL_1;
+    public final ItemGeneratorPool TEAM_LVL_2;
+    public final ItemGeneratorPool TEAM_LVL_3;
+
+    public final ItemGeneratorPool DIAMOND;
+
+    public final ItemGeneratorPool EMERALD;
+
+    public ItemGeneratorPools(BwConfig config) {
+        var generatorConfig = config.generatorConfig();
+
+        TEAM_LVL_1 = new ItemGeneratorPool()
+                .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level1().ironSpawnRate())
+                .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level1().goldSpawnRate())
+                .spawnInterval(generatorConfig.level1().spawnIntervalTicks());
+
+        TEAM_LVL_2 = new ItemGeneratorPool()
+                .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level2().ironSpawnRate())
+                .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level2().goldSpawnRate())
+                .add(new ItemStack(Items.IRON_INGOT, 2), generatorConfig.level2().ironSpawnRate() / 3)
+                .spawnInterval(generatorConfig.level2().spawnIntervalTicks());
+
+        TEAM_LVL_3 = new ItemGeneratorPool()
+                .add(new ItemStack(Items.IRON_INGOT, 1), generatorConfig.level3().ironSpawnRate())
+                .add(new ItemStack(Items.IRON_INGOT, 2), generatorConfig.level3().ironSpawnRate() / 2)
+                .add(new ItemStack(Items.GOLD_INGOT, 1), generatorConfig.level3().goldSpawnRate())
+                .add(new ItemStack(Items.GOLD_INGOT, 2), generatorConfig.level3().goldSpawnRate() / 3)
+                .add(new ItemStack(Items.EMERALD, 1), 1)
+                .spawnInterval(generatorConfig.level3().spawnIntervalTicks());
+
+        DIAMOND = new ItemGeneratorPool()
+                .add(new ItemStack(Items.DIAMOND, 1), generatorConfig.diamond())
+                .spawnInterval(generatorConfig.diamondSpawnInterval());
+
+        EMERALD = new ItemGeneratorPool()
+                .add(new ItemStack(Items.EMERALD, 1), generatorConfig.emerald())
+                .spawnInterval(generatorConfig.emeraldSpawnInterval());
+    }
+}

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/shop/BwTeamShop.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/shop/BwTeamShop.java
@@ -106,7 +106,7 @@ public final class BwTeamShop {
                     .withCost((p, e) -> Cost.ofDiamonds(teamScaledCost(game, team, stagedUpgrade(1, teamSpawn.getLevel()))))
                     .onBuyCheck((p, e) -> teamSpawn.getLevel() < BwMap.TeamSpawn.MAX_LEVEL && e.getCost(p).takeItems(p))
                     .onBuy(p -> {
-                        teamSpawn.setLevel(teamSpawn.getLevel() + 1, game.getPools());
+                        teamSpawn.setLevel(teamSpawn.getLevel() + 1, game.map.pools);
                         game.broadcast.broadcastToTeam(participant.team, new TranslatableText("text.bedwars.shop.upgrade.generator.buy", p.getDisplayName().shallowCopy(), teamSpawn.getLevel()).formatted(Formatting.BOLD, Formatting.AQUA));
                     })
             );

--- a/src/main/java/xyz/nucleoid/bedwars/game/active/shop/BwTeamShop.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/shop/BwTeamShop.java
@@ -106,7 +106,7 @@ public final class BwTeamShop {
                     .withCost((p, e) -> Cost.ofDiamonds(teamScaledCost(game, team, stagedUpgrade(1, teamSpawn.getLevel()))))
                     .onBuyCheck((p, e) -> teamSpawn.getLevel() < BwMap.TeamSpawn.MAX_LEVEL && e.getCost(p).takeItems(p))
                     .onBuy(p -> {
-                        teamSpawn.setLevel(teamSpawn.getLevel() + 1);
+                        teamSpawn.setLevel(teamSpawn.getLevel() + 1, game.getPools());
                         game.broadcast.broadcastToTeam(participant.team, new TranslatableText("text.bedwars.shop.upgrade.generator.buy", p.getDisplayName().shallowCopy(), teamSpawn.getLevel()).formatted(Formatting.BOLD, Formatting.AQUA));
                     })
             );

--- a/src/main/java/xyz/nucleoid/bedwars/game/config/BwConfig.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/config/BwConfig.java
@@ -1,4 +1,4 @@
-package xyz.nucleoid.bedwars.game;
+package xyz.nucleoid.bedwars.game.config;
 
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
@@ -21,7 +21,8 @@ public record BwConfig(
         List<GameModifier> modifiers,
         GameTeamList teams,
         PlayerConfig players,
-        boolean keepInventory
+        boolean keepInventory,
+        GeneratorConfig generatorConfig
 ) {
     public static final Codec<BwConfig> CODEC = RecordCodecBuilder.create(instance -> {
         return instance.group(
@@ -31,7 +32,8 @@ public record BwConfig(
                 GameModifier.CODEC.listOf().optionalFieldOf("modifiers", Collections.emptyList()).forGetter(BwConfig::modifiers),
                 GameTeamList.CODEC.fieldOf("teams").forGetter(BwConfig::teams),
                 PlayerConfig.CODEC.fieldOf("players").forGetter(BwConfig::players),
-                Codec.BOOL.optionalFieldOf("keep_inventory", false).forGetter(BwConfig::keepInventory)
+                Codec.BOOL.optionalFieldOf("keep_inventory", false).forGetter(BwConfig::keepInventory),
+                GeneratorConfig.CODEC.fieldOf("generator").forGetter(BwConfig::generatorConfig)
         ).apply(instance, BwConfig::new);
     });
 }

--- a/src/main/java/xyz/nucleoid/bedwars/game/config/GeneratorConfig.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/config/GeneratorConfig.java
@@ -1,0 +1,26 @@
+package xyz.nucleoid.bedwars.game.config;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+public record GeneratorConfig(GeneratorLevelConfig level1, GeneratorLevelConfig level2, GeneratorLevelConfig level3, int diamond, long diamondSpawnInterval, int emerald, long emeraldSpawnInterval) {
+    public static final Codec<GeneratorConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            GeneratorLevelConfig.CODEC.fieldOf("level_1").forGetter(GeneratorConfig::level1),
+            GeneratorLevelConfig.CODEC.fieldOf("level_2").forGetter(GeneratorConfig::level2),
+            GeneratorLevelConfig.CODEC.fieldOf("level_3").forGetter(GeneratorConfig::level3),
+            Codec.INT.fieldOf("diamond").forGetter(GeneratorConfig::diamond),
+            Codec.LONG.fieldOf("diamondSpawnInterval").forGetter(GeneratorConfig::diamondSpawnInterval),
+            Codec.INT.fieldOf("emerald").forGetter(GeneratorConfig::emerald),
+            Codec.LONG.fieldOf("emeraldSpawnInterval").forGetter(GeneratorConfig::emeraldSpawnInterval)
+    ).apply(instance, GeneratorConfig::new));
+
+    public static record GeneratorLevelConfig(int ironSpawnRate, int goldSpawnRate, int emeraldSpawnRate, int diamondSpawnRate, long spawnIntervalTicks) {
+        public static final Codec<GeneratorLevelConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                Codec.INT.fieldOf("iron").forGetter(GeneratorLevelConfig::ironSpawnRate),
+                Codec.INT.fieldOf("gold").forGetter(GeneratorLevelConfig::goldSpawnRate),
+                Codec.INT.optionalFieldOf("emerald", 0).forGetter(GeneratorLevelConfig::emeraldSpawnRate),
+                Codec.INT.optionalFieldOf("diamond", 0).forGetter(GeneratorLevelConfig::diamondSpawnRate),
+                Codec.LONG.fieldOf("spawnIntervalTicks").forGetter(GeneratorLevelConfig::spawnIntervalTicks)
+        ).apply(instance, GeneratorLevelConfig::new));
+    }
+}

--- a/src/main/java/xyz/nucleoid/bedwars/game/config/GeneratorConfig.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/config/GeneratorConfig.java
@@ -9,9 +9,9 @@ public record GeneratorConfig(GeneratorLevelConfig level1, GeneratorLevelConfig 
             GeneratorLevelConfig.CODEC.fieldOf("level_2").forGetter(GeneratorConfig::level2),
             GeneratorLevelConfig.CODEC.fieldOf("level_3").forGetter(GeneratorConfig::level3),
             Codec.INT.fieldOf("diamond").forGetter(GeneratorConfig::diamond),
-            Codec.LONG.fieldOf("diamondSpawnInterval").forGetter(GeneratorConfig::diamondSpawnInterval),
+            Codec.LONG.fieldOf("diamond_spawn_interval").forGetter(GeneratorConfig::diamondSpawnInterval),
             Codec.INT.fieldOf("emerald").forGetter(GeneratorConfig::emerald),
-            Codec.LONG.fieldOf("emeraldSpawnInterval").forGetter(GeneratorConfig::emeraldSpawnInterval)
+            Codec.LONG.fieldOf("emerald_spawn_interval").forGetter(GeneratorConfig::emeraldSpawnInterval)
     ).apply(instance, GeneratorConfig::new));
 
     public static record GeneratorLevelConfig(int ironSpawnRate, int goldSpawnRate, int emeraldSpawnRate, int diamondSpawnRate, long spawnIntervalTicks) {
@@ -20,7 +20,7 @@ public record GeneratorConfig(GeneratorLevelConfig level1, GeneratorLevelConfig 
                 Codec.INT.fieldOf("gold").forGetter(GeneratorLevelConfig::goldSpawnRate),
                 Codec.INT.optionalFieldOf("emerald", 0).forGetter(GeneratorLevelConfig::emeraldSpawnRate),
                 Codec.INT.optionalFieldOf("diamond", 0).forGetter(GeneratorLevelConfig::diamondSpawnRate),
-                Codec.LONG.fieldOf("spawnIntervalTicks").forGetter(GeneratorLevelConfig::spawnIntervalTicks)
+                Codec.LONG.fieldOf("spawn_interval_ticks").forGetter(GeneratorLevelConfig::spawnIntervalTicks)
         ).apply(instance, GeneratorLevelConfig::new));
     }
 }

--- a/src/main/java/xyz/nucleoid/bedwars/game/generator/BwSkyMapBuilder.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/generator/BwSkyMapBuilder.java
@@ -2,7 +2,7 @@ package xyz.nucleoid.bedwars.game.generator;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
-import xyz.nucleoid.bedwars.game.BwConfig;
+import xyz.nucleoid.bedwars.game.config.BwConfig;
 import xyz.nucleoid.bedwars.game.BwMap;
 import xyz.nucleoid.bedwars.game.generator.island.BwCenterIsland;
 import xyz.nucleoid.bedwars.game.generator.island.BwDiamondIsland;

--- a/src/main/java/xyz/nucleoid/bedwars/game/generator/BwSkyMapBuilder.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/generator/BwSkyMapBuilder.java
@@ -24,7 +24,7 @@ public final class BwSkyMapBuilder {
     }
 
     public BwMap build(MinecraftServer server) {
-        BwMap map = new BwMap();
+        BwMap map = new BwMap(config);
 
         MapTemplate template = MapTemplate.createEmpty();
 

--- a/src/main/java/xyz/nucleoid/bedwars/game/generator/island/BwTeamIsland.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/generator/island/BwTeamIsland.java
@@ -8,6 +8,7 @@ import net.minecraft.block.enums.BedPart;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import xyz.nucleoid.bedwars.game.BwMap;
+import xyz.nucleoid.bedwars.game.active.ItemGeneratorPools;
 import xyz.nucleoid.bedwars.game.generator.BwSkyMapConfig;
 import xyz.nucleoid.map_templates.BlockBounds;
 import xyz.nucleoid.map_templates.MapTemplate;
@@ -101,7 +102,7 @@ public final class BwTeamIsland {
         map.addProtectedBlocks(bed);
 
         Direction shopDirection = this.direction.rotateYClockwise();
-        map.addTeamRegions(this.team.key(), new BwMap.TeamRegions(spawn, bed, base, chest, itemShop, teamShop, shopDirection, shopDirection));
+        map.addTeamRegions(this.team.key(), new BwMap.TeamRegions(spawn, bed, base, chest, itemShop, teamShop, shopDirection, shopDirection), map.pools);
     }
 
     private BlockPos transformPosition(int x, int y, int z) {

--- a/src/main/java/xyz/nucleoid/bedwars/mixin/BedBlockMixin.java
+++ b/src/main/java/xyz/nucleoid/bedwars/mixin/BedBlockMixin.java
@@ -17,7 +17,7 @@ public class BedBlockMixin {
 	 *
 	 * @author SuperCoder79
 	 */
-	@Inject(method = "isOverworld", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "isBedWorking", at = @At("HEAD"), cancellable = true)
 	private static void noExplosion(World world, CallbackInfoReturnable<Boolean> cir) {
 		ManagedGameSpace gameSpace = GameSpaceManager.get().byWorld(world);
 		if (gameSpace != null) {

--- a/src/main/resources/data/bedwars/games/eight_teams/beach.json
+++ b/src/main/resources/data/bedwars/games/eight_teams/beach.json
@@ -21,5 +21,27 @@
     {"key": "orange", "name": "Orange", "color": "orange"},
     {"key": "red", "name": "Red", "color": "red"},
     {"key": "purple", "name": "Purple", "color": "purple"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/eight_teams/beach.json
+++ b/src/main/resources/data/bedwars/games/eight_teams/beach.json
@@ -26,22 +26,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/cubes.json
+++ b/src/main/resources/data/bedwars/games/four_teams/cubes.json
@@ -22,22 +22,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/cubes.json
+++ b/src/main/resources/data/bedwars/games/four_teams/cubes.json
@@ -17,5 +17,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/four_teams/desert.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/four_teams/desert.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/forest.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/forest.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
+++ b/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
@@ -18,5 +18,27 @@
     {"key": "crimson", "name": "Crimson", "color": "red"},
     {"key": "soul", "name": "Soul", "color": "brown"},
     {"key": "basalt", "name": "Basalt", "color": "gray"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
+++ b/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
@@ -23,22 +23,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/logs.json
+++ b/src/main/resources/data/bedwars/games/four_teams/logs.json
@@ -22,22 +22,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/logs.json
+++ b/src/main/resources/data/bedwars/games/four_teams/logs.json
@@ -17,5 +17,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/monument.json
+++ b/src/main/resources/data/bedwars/games/four_teams/monument.json
@@ -22,22 +22,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/monument.json
+++ b/src/main/resources/data/bedwars/games/four_teams/monument.json
@@ -17,5 +17,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/mountains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/mountains.json
@@ -22,22 +22,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/mountains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/mountains.json
@@ -17,5 +17,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/plains.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/plains.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/roadway.json
+++ b/src/main/resources/data/bedwars/games/four_teams/roadway.json
@@ -22,22 +22,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/roadway.json
+++ b/src/main/resources/data/bedwars/games/four_teams/roadway.json
@@ -17,5 +17,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/four_teams/swamp.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/four_teams/swamp.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/four_teams/taiga.json
@@ -64,22 +64,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/four_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/four_teams/taiga.json
@@ -59,5 +59,27 @@
     {"key": "green", "name": "Green", "color": "green"},
     {"key": "yellow", "name": "Yellow", "color": "yellow"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/two_teams/desert.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/two_teams/desert.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/end.json
+++ b/src/main/resources/data/bedwars/games/two_teams/end.json
@@ -20,22 +20,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/end.json
+++ b/src/main/resources/data/bedwars/games/two_teams/end.json
@@ -15,5 +15,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/forest.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/forest.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/two_teams/plains.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/two_teams/plains.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/two_teams/swamp.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/two_teams/swamp.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "lily_pad", "name": "Lily Pad", "color": "green"},
     {"key": "dirt", "name": "Dirt", "color": "brown"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/two_teams/taiga.json
@@ -62,22 +62,22 @@
     "level_1": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 34
+      "spawn_interval_ticks": 34
     },
     "level_2": {
       "gold": 2,
       "iron": 10,
-      "spawnIntervalTicks": 30
+      "spawn_interval_ticks": 30
     },
     "level_3": {
       "gold": 9,
       "iron": 36,
       "emerald": 1,
-      "spawnIntervalTicks": 26
+      "spawn_interval_ticks": 26
     },
     "diamond": 1,
-    "diamondSpawnInterval": 900,
+    "diamond_spawn_interval": 900,
     "emerald": 1,
-    "emeraldSpawnInterval": 1800
+    "emerald_spawn_interval": 1800
   }
 }

--- a/src/main/resources/data/bedwars/games/two_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/two_teams/taiga.json
@@ -57,5 +57,27 @@
   "teams": [
     {"key": "blue", "name": "Blue", "color": "blue"},
     {"key": "red", "name": "Red", "color": "red"}
-  ]
+  ],
+  "generator": {
+    "level_1": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 34
+    },
+    "level_2": {
+      "gold": 2,
+      "iron": 10,
+      "spawnIntervalTicks": 30
+    },
+    "level_3": {
+      "gold": 9,
+      "iron": 36,
+      "emerald": 1,
+      "spawnIntervalTicks": 26
+    },
+    "diamond": 1,
+    "diamondSpawnInterval": 900,
+    "emerald": 1,
+    "emeraldSpawnInterval": 1800
+  }
 }


### PR DESCRIPTION
This PR adds a generator field to all map config files. This allows fine-tuning of spawn chances and speeds of items in all generators, allowing for per-map balancing. This approach means that the overall increasing of rates in #41 is not needed - small maps can be tweaked to have slower generators and vice versa


Default generator speed as of before this PR:

```json
"generator": {
    "level_1": {
      "gold": 2,
      "iron": 10,
      "spawn_interval_ticks": 34
    },
    "level_2": {
      "gold": 2,
      "iron": 10,
      "spawn_interval_ticks": 30
    },
    "level_3": {
      "gold": 9,
      "iron": 36,
      "emerald": 1,
      "spawn_interval_ticks": 26
    },
    "diamond": 1,
    "diamond_spawn_interval": 900,
    "emerald": 1,
    "emerald_spawn_interval": 1800
  }
```