### PR TITLE
Disable saturated regeneration

### DIFF
--- a/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
+++ b/src/main/java/xyz/nucleoid/bedwars/game/active/BwActive.java
@@ -132,6 +132,7 @@ public final class BwActive {
             activity.deny(GameRuleType.CRAFTING);
             activity.allow(GameRuleType.FALL_DAMAGE);
             activity.deny(GameRuleType.HUNGER);
+            activity.deny(GameRuleType.SATURATED_REGENERATION);
             activity.allow(GameRuleType.TRIDENTS_LOYAL_IN_VOID);
             activity.allow(BedWars.BLAST_PROOF_GLASS_RULE);
             activity.allow(BedWars.LEAVES_DROP_GOLDEN_APPLES);


### PR DESCRIPTION
This pull request disables the saturated regeneration rule type. Since hunger is disabled in this game, saturated regeneration will always occur, and players will regenerate health too quickly for combat to quickly end.

Saturated regeneration is already disabled in Cake Wars, Cabin Fever, and Farmy Feud; there is also [a pull request](https://github.com/NucleoidMC/survival-games/pull/17) to disable saturated regeneration in Survival Games.