### PR TITLE
Fix descriptions not using translatable text

### DIFF
--- a/src/main/resources/data/bedwars/games/eight_teams/beach.json
+++ b/src/main/resources/data/bedwars/games/eight_teams/beach.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:beach",
   "players": {
     "min": 1,

--- a/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/aspen_forest.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:aspen_forest"

--- a/src/main/resources/data/bedwars/games/four_teams/cubes.json
+++ b/src/main/resources/data/bedwars/games/four_teams/cubes.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:cubes",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/four_teams/desert.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:desert"

--- a/src/main/resources/data/bedwars/games/four_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/four_teams/forest.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:forest"

--- a/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
+++ b/src/main/resources/data/bedwars/games/four_teams/hellish_nightmare.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:hellish_nightmare",
   "dimension": "minecraft:the_nether",
   "players": {

--- a/src/main/resources/data/bedwars/games/four_teams/logs.json
+++ b/src/main/resources/data/bedwars/games/four_teams/logs.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:logs",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/modern.json
+++ b/src/main/resources/data/bedwars/games/four_teams/modern.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:modern",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:modern",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/monument.json
+++ b/src/main/resources/data/bedwars/games/four_teams/monument.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:monument",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/mountains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/mountains.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:mountains",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/overgrown.json
+++ b/src/main/resources/data/bedwars/games/four_teams/overgrown.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:overgrown",
   "players": {
     "min": 4,

--- a/src/main/resources/data/bedwars/games/four_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/four_teams/plains.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:plains"

--- a/src/main/resources/data/bedwars/games/four_teams/roadway.json
+++ b/src/main/resources/data/bedwars/games/four_teams/roadway.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:roadway",
   "players": {
     "min": 1,

--- a/src/main/resources/data/bedwars/games/four_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/four_teams/swamp.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:swamp"

--- a/src/main/resources/data/bedwars/games/four_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/four_teams/taiga.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:taiga"

--- a/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/aspen_forest.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:aspen_forest"

--- a/src/main/resources/data/bedwars/games/two_teams/desert.json
+++ b/src/main/resources/data/bedwars/games/two_teams/desert.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:desert"

--- a/src/main/resources/data/bedwars/games/two_teams/end.json
+++ b/src/main/resources/data/bedwars/games/two_teams/end.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": "bedwars:end",
   "players": {
     "min": 2,

--- a/src/main/resources/data/bedwars/games/two_teams/forest.json
+++ b/src/main/resources/data/bedwars/games/two_teams/forest.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:forest"

--- a/src/main/resources/data/bedwars/games/two_teams/plains.json
+++ b/src/main/resources/data/bedwars/games/two_teams/plains.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:plains"

--- a/src/main/resources/data/bedwars/games/two_teams/swamp.json
+++ b/src/main/resources/data/bedwars/games/two_teams/swamp.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:swamp"

--- a/src/main/resources/data/bedwars/games/two_teams/taiga.json
+++ b/src/main/resources/data/bedwars/games/two_teams/taiga.json
@@ -1,7 +1,14 @@
 {
   "type": "bedwars:bed_wars",
   "icon": "minecraft:red_bed",
-  "description": "game.bedwars.desc",
+  "description": [
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.1"
+    },
+    {
+      "translate": "gameType.bedwars.bed_wars.desc.2"
+    }
+  ],
   "map": {
     "theme": {
       "type": "bedwars:taiga"

--- a/src/main/resources/data/bedwars/lang/en_us.json
+++ b/src/main/resources/data/bedwars/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "gameType.bedwars.bed_wars": "Bed Wars",
-  "game.bedwars.desc": "In Bed Wars, teams must battle in the sky to destroy the other teams' beds!",
+  "gameType.bedwars.bed_wars.desc.1": "Teams must battle in the sky to",
+  "gameType.bedwars.bed_wars.desc.2": "destroy the other teams' beds!",
   "game.bedwars.four_teams.aspen_forest": "Bed Wars: Aspen Forest (4 Teams)",
   "game.bedwars.four_teams.cubes": "Bed Wars: Cubes (4 Teams)",
   "game.bedwars.four_teams.desert": "Bed Wars: Desert (4 Teams)",


### PR DESCRIPTION
<img width="580" alt="Game waiting lobby sidebar with description reading 'Teams must battle in the sky to destroy the other teams' beds!'" src="https://github.com/user-attachments/assets/abd9a615-13c0-4915-8572-ac1e9a20df38">

Fixes #70